### PR TITLE
fix(immich): enable tailscale funnel on main ingress for public share links

### DIFF
--- a/apps/immich/ingress.yaml
+++ b/apps/immich/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-ingress
   namespace: immich
   annotations:
-    # Allow large file uploads for photos/videos
+    tailscale.com/funnel: "true"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
 spec:
   ingressClassName: tailscale
@@ -13,30 +13,6 @@ spec:
       http:
         paths:
           - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: immich-server
-                port:
-                  number: 2283
-  tls:
-    - hosts:
-        - immich
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: immich-ingress-public
-  namespace: immich
-  annotations:
-    tailscale.com/funnel: "true"
-spec:
-  ingressClassName: tailscale
-  rules:
-    - host: immich
-      http:
-        paths:
-          - path: /share
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## Summary
- Consolidates funnel onto the single `immich-ingress` so public share links use the same hostname Immich generates
- Removes the separate `immich-ingress-public` ingress that caused a hostname conflict

## Test plan
- [ ] ArgoCD syncs the updated ingress
- [ ] `https://immich.bumblebee-themis.ts.net/share/<id>` is reachable publicly