### PR TITLE
feat(velero): exclude media namespace from backups

### DIFF
--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -43,6 +43,7 @@ schedules:
         - "*"
       excludedNamespaces:
         - velero
+        - media
   weekly:
     schedule: "10 0 * * 0"
     template:
@@ -52,6 +53,7 @@ schedules:
         - "*"
       excludedNamespaces:
         - velero
+        - media
   monthly:
     schedule: "15 0 1 * *"
     template:
@@ -61,3 +63,4 @@ schedules:
         - "*"
       excludedNamespaces:
         - velero
+        - media


### PR DESCRIPTION
Adds `media` to `excludedNamespaces` in all three Velero schedules (daily/weekly/monthly).