### PR TITLE
fix(velero): include CRDs in helm render

### DIFF
--- a/apps/velero/kustomization.yaml
+++ b/apps/velero/kustomization.yaml
@@ -15,4 +15,5 @@ helmCharts:
     repo: https://vmware-tanzu.github.io/helm-charts
     version: 12.0.1
     namespace: velero
+    includeCRDs: true
     valuesFile: values.yaml


### PR DESCRIPTION
## Summary
- Add `includeCRDs: true` to velero helmCharts entry so Schedule + other Velero CRDs render and apply.

Fixes ArgoCD sync error: `Kubernetes API could not find velero.io/Schedule`.

## Test plan
- [ ] ArgoCD syncs velero app cleanly
- [ ] `kubectl get crd | grep velero.io` shows Schedule, Backup, Restore, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)