### PR TITLE
fix(immich): move ingress.yaml from generators to resources

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -7,10 +7,10 @@ resources:
   - namespace.yaml
   - pvc.yaml
   - postgres-cluster.yaml
+  - ingress.yaml
 
 generators:
   - secret-generator.yaml
-  - ingress.yaml
 
 helmCharts:
   - name: immich


### PR DESCRIPTION
ArgoCD sync failed with `unable to find plugin root` because `ingress.yaml` was listed under `generators:` but lacks the `config.kubernetes.io/function` annotation. Kustomize tried to load it as a plugin. Moved to `resources:`.