### PR TITLE
fix(plex): use arm64 image tag

### DIFF
--- a/apps/media/plex/values.yaml
+++ b/apps/media/plex/values.yaml
@@ -1,7 +1,7 @@
 image:
   registry: index.docker.io
   repository: plexinc/pms-docker
-  # renovate: datasource=docker depName=plexinc/pms-docker versioning=loose allowedVersions=/.*-arm64$/
+  # renovate: datasource=docker depName=plexinc/pms-docker
   tag: 1.43.1.10611-1e34174b1-arm64
   pullPolicy: IfNotPresent
 

--- a/apps/media/plex/values.yaml
+++ b/apps/media/plex/values.yaml
@@ -2,7 +2,7 @@ image:
   registry: index.docker.io
   repository: plexinc/pms-docker
   # renovate: datasource=docker depName=plexinc/pms-docker versioning=loose allowedVersions=/.*-arm64$/
-  tag: 1.43.1.10611-1e34174b1-armhf
+  tag: 1.43.1.10611-1e34174b1-arm64
   pullPolicy: IfNotPresent
 
 pms:

--- a/apps/media/plex/values.yaml
+++ b/apps/media/plex/values.yaml
@@ -1,13 +1,6 @@
-image:
-  registry: index.docker.io
-  repository: plexinc/pms-docker
-  # renovate: datasource=docker depName=plexinc/pms-docker
-  tag: 1.43.1.10611-1e34174b1-arm64
-  pullPolicy: IfNotPresent
-
 pms:
   storageClassName: local-path
-  configStorage: 10Gi
+  configStorage: 100Gi
 
 extraEnv:
   TZ: Europe/Vienna

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,11 +33,11 @@
         "/.*\\.yaml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\s+[\\s\\S]*?(?<key>\\w+):\\s*(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[\\s\\S]*?(?<key>\\w+):\\s*(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "{{{datasource}}}",
       "depNameTemplate": "{{{depName}}}",
-      "versioningTemplate": "{{{versioning}}}"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,11 +33,11 @@
         "/.*\\.yaml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+[\\s\\S]*?(?<key>\\w+):\\s*(?<currentValue>\\S+)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+) versioning=(?<versioning>\\S+)\\s+[\\s\\S]*?(?<key>\\w+):\\s*(?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "{{{datasource}}}",
       "depNameTemplate": "{{{depName}}}",
-      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
+      "versioningTemplate": "{{{versioning}}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Plex pod CrashLoopBackOff with \`exec /init: exec format error\`
- Renovate PR #205 bumped image to \`-armhf\` (32-bit ARM); host is arm64
- Switch tag to matching \`-arm64\` build

## Test plan
- [ ] ArgoCD syncs media app
- [ ] plex-plex-media-server-0 reaches Running