### PR TITLE
fix(media): wait for postgres + liveness probes on arr apps

### DIFF
--- a/apps/media/prowlarr/deployment.yaml
+++ b/apps/media/prowlarr/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       labels:
         app: prowlarr
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - until nc -z preparr-postgres-rw 5432; do echo waiting for postgres; sleep 2; done
       containers:
         - name: prowlarr
           # renovate: datasource=docker depName=linuxserver/prowlarr versioning=docker
           image: linuxserver/prowlarr:2.3.5
+          livenessProbe:
+            tcpSocket:
+              port: 9696
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           env:
             - name: TZ
               value: Europe/Vienna

--- a/apps/media/radarr/deployment.yaml
+++ b/apps/media/radarr/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       labels:
         app: radarr
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - until nc -z preparr-postgres-rw 5432; do echo waiting for postgres; sleep 2; done
       containers:
         - name: radarr
           # renovate: datasource=docker depName=linuxserver/radarr versioning=docker
           image: linuxserver/radarr:6.1.1
+          livenessProbe:
+            tcpSocket:
+              port: 7878
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           env:
             - name: TZ
               value: Europe/Vienna

--- a/apps/media/sonarr/deployment.yaml
+++ b/apps/media/sonarr/deployment.yaml
@@ -13,10 +13,23 @@ spec:
       labels:
         app: sonarr
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - until nc -z preparr-postgres-rw 5432; do echo waiting for postgres; sleep 2; done
       containers:
         - name: sonarr
           # renovate: datasource=docker depName=linuxserver/sonarr versioning=docker
           image: linuxserver/sonarr:4.0.17
+          livenessProbe:
+            tcpSocket:
+              port: 8989
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
           env:
             - name: TZ
               value: Europe/Vienna


### PR DESCRIPTION
## Summary
- Sonarr/Prowlarr crashed today: started before \`preparr-postgres-rw\` had endpoints, hit \`Connection refused\`, entered non-recoverable wait state. Pod stayed Running but app was dead — bootstrap PostSync hook timed out → ArgoCD app stuck Progressing.
- Add initContainer waiting for tcp:preparr-postgres-rw:5432 before main app starts.
- Add tcpSocket livenessProbe so kubelet restarts pod if app dies internally.

## Test plan
- [ ] ArgoCD syncs media app
- [ ] arr pods reach Running with init container completed
- [ ] media-bootstrap completes