### PR TITLE
feat(kyverno): add kyverno with cluster-wide timezone injection

### DIFF
--- a/apps/kyverno/kustomization.yaml
+++ b/apps/kyverno/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: kyverno
+
+resources:
+  - namespace.yaml
+  - timezone-policy.yaml
+
+helmCharts:
+  - name: kyverno
+    releaseName: kyverno
+    repo: https://kyverno.github.io/kyverno/
+    namespace: kyverno
+    # renovate: datasource=helm depName=kyverno registryUrl=https://kyverno.github.io/kyverno/ versioning=semver
+    version: 3.8.0

--- a/apps/kyverno/namespace.yaml
+++ b/apps/kyverno/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kyverno

--- a/apps/kyverno/timezone-policy.yaml
+++ b/apps/kyverno/timezone-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: inject-timezone
+spec:
+  rules:
+    - name: inject-tz-env
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      mutate:
+        patchStrategicMerge:
+          spec:
+            containers:
+              - (name): "?*"
+                env:
+                  - name: TZ
+                    value: Europe/Vienna
+            initContainers:
+              - (name): "?*"
+                env:
+                  - name: TZ
+                    value: Europe/Vienna


### PR DESCRIPTION
## Summary
- Deploys Kyverno v3.8.0 via Helm
- Adds `ClusterPolicy` that mutates all pods to inject `TZ=Europe/Vienna`
- Fixes Velero backups running 2h late due to UTC vs CEST offset

## Test plan
- [ ] ArgoCD syncs `kyverno` namespace and Helm chart
- [ ] `ClusterPolicy` `inject-timezone` shows as ready
- [ ] New pods get `TZ=Europe/Vienna` env var injected
- [ ] Velero next scheduled backup runs at midnight Vienna time

🤖 Generated with [Claude Code](https://claude.com/claude-code)