### PR TITLE
fix(argocd): ignore Kyverno ClusterPolicy and CRD drift

### DIFF
--- a/apps/argocd/applicationset.yaml
+++ b/apps/argocd/applicationset.yaml
@@ -32,6 +32,21 @@ spec:
             - .spec.volumeClaimTemplates[]?.kind
             - .spec.volumeClaimTemplates[]?.status
             - .spec.volumeClaimTemplates[]?.spec.volumeMode
+        - group: kyverno.io
+          kind: ClusterPolicy
+          jqPathExpressions:
+            - .spec.admission
+            - .spec.background
+            - .spec.emitWarning
+            - .spec.validationFailureAction
+            - .spec.rules[].skipBackgroundRequests
+            - .status
+        - group: apiextensions.k8s.io
+          kind: CustomResourceDefinition
+          jqPathExpressions:
+            - .spec.conversion
+            - .spec.preserveUnknownFields
+            - .status
       syncPolicy:
         syncOptions:
         - CreateNamespace=true


### PR DESCRIPTION
## Summary
- Kyverno mutates `ClusterPolicy` in-cluster after admission (adds `autogen` rules, `admission`/`background`/`emitWarning` defaults, `status`)
- Several Kyverno CRDs get defaulted fields added by the API server
- ArgoCD sees all these as OutOfSync despite ServerSideApply being on

## Fix
Add `ignoreDifferences` entries in the ApplicationSet for:
- `kyverno.io/ClusterPolicy` — spec defaults and status
- `apiextensions.k8s.io/CustomResourceDefinition` — conversion, preserveUnknownFields, status

## Test plan
- [ ] ArgoCD kyverno app shows Synced after next reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)