### PR TITLE
fix(argocd): use managedFieldsManagers to ignore CRD apiserver fields

### DIFF
--- a/apps/argocd/applicationset.yaml
+++ b/apps/argocd/applicationset.yaml
@@ -43,9 +43,9 @@ spec:
             - .status
         - group: apiextensions.k8s.io
           kind: CustomResourceDefinition
+          managedFieldsManagers:
+            - apiserver
           jqPathExpressions:
-            - .spec.conversion
-            - .spec.preserveUnknownFields
             - .status
       syncPolicy:
         syncOptions:


### PR DESCRIPTION
## Summary
- Previous fix used `jqPathExpressions` for `.spec.conversion` on CRDs but ArgoCD ServerSideApply dry-run also returns the field — so desired vs live diff never resolved
- Switch to `managedFieldsManagers: [apiserver]` which excludes all fields owned by the API server from diff comparison

## Test plan
- [ ] Kyverno app shows Synced after ArgoCD reconciles

🤖 Generated with [Claude Code](https://claude.com/claude-code)