### PR TITLE
fix(argocd): ignore CRD fields managed by k3s not apiserver

### DIFF
--- a/apps/argocd/applicationset.yaml
+++ b/apps/argocd/applicationset.yaml
@@ -44,7 +44,7 @@ spec:
         - group: apiextensions.k8s.io
           kind: CustomResourceDefinition
           managedFieldsManagers:
-            - apiserver
+            - k3s
           jqPathExpressions:
             - .status
       syncPolicy:


### PR DESCRIPTION
## Summary
- Previous fix used `managedFieldsManagers: [apiserver]` but on K3s the CRD defaulted fields (e.g. `spec.conversion`) are owned by manager `k3s`
- Switch to `managedFieldsManagers: [k3s]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)