### PR TITLE
feat(velero): set custom kopia repository password

### DIFF
--- a/apps/velero/repo-credentials.sops.yaml
+++ b/apps/velero/repo-credentials.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: velero-repo-credentials
+    namespace: velero
+type: Opaque
+stringData:
+    repository-password: ENC[AES256_GCM,data:QR0K62iglfz4XmjiuV92RcCzDVMZQBwYy2YsR+1hLCq3YCc5UVd/etHUyQI=,iv:ndHDh+7H2VX76Sy+8wJ3AjUt0DImAOD744RJCy3hELk=,tag:0wU8hVpfGfSFwJlZsAyA0g==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUTkreUhiVUhWaFpMS1Bn
+            ZWRNUlo5Wmp3bEsvSkUydXF3SEI0eVFTUG0wCjZERUliY3RrMWN5Ty9DNmI2aUQ4
+            MW5LcExrWFZyTzdscEwvdUdqcVVWcmcKLS0tIDE1b09ZNm03T3ZwbmhpaW4za3Zm
+            NnRuVlhXdVQ1d3JpR1NRcXdZeW9USVUKiFoh75A45J2S1zQkyCbUfV8ZkwYnoVTc
+            3ipAP2+3lg0UUaTDZoZaLb3Kee4gc3Q7g9EzB81QAETM0g1vNpf9RQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1887g842zprdv8sculknt80wx4awhfh6mjzst9cxju3lpf9xeq5xslndmcd
+    lastmodified: "2026-05-22T19:01:19Z"
+    mac: ENC[AES256_GCM,data:Oi1XeXPh/sKuHJaNywJtlMjuKJe5Br/4JcbT1qepzoVZ2tBglrRq0e1Pd/Qw8pyQl+532kB5+FjFCc9L0hEk3Qjsooy72fJOp1YrOwtD28GmR1UuWuQA47EB4LwR8Eeybj+PJuJeUosGhkck/f97Bov7Bjn9kRUfKDYpGWslUT8=,iv:TZTHz5a2ka+0VuikuOBnNaMbYy9d7ljDfzLvS4XMiq0=,tag:5DWvKZ2W/YhY1hpUM37OmQ==,type:str]
+    unencrypted_regex: ^(apiVersion|metadata|kind|type)$
+    version: 3.13.0

--- a/apps/velero/secret-generator.yaml
+++ b/apps/velero/secret-generator.yaml
@@ -8,3 +8,4 @@ metadata:
         path: ksops
 files:
   - secret.sops.yaml
+  - repo-credentials.sops.yaml


### PR DESCRIPTION
## Summary
- Add sops-encrypted `velero-repo-credentials` secret with random `repository-password`
- Velero auto-uses this secret name; replaces hardcoded `static-passw0rd` for kopia fs-backup encryption

## Caveat
Existing kopia repo was initialized under the old default password — old backups become unreadable after rollout. Fresh backups needed.

## Scope of encryption
Only PV data (fs-backup via kopia) is encrypted. Kubernetes resource manifest tarballs Velero writes to S3 remain plaintext; mitigate via Garage SSE / TLS if needed.

## Test plan
- [ ] ArgoCD sync passes
- [ ] `velero-repo-credentials` secret present in `velero` ns with `repository-password` key
- [ ] Manual backup completes
- [ ] kopia repo connect uses new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)