### PR TITLE
chore: trigger backups at 23:06 Vienna for smoke test

### DIFF
--- a/apps/immich/postgres-scheduledbackup.yaml
+++ b/apps/immich/postgres-scheduledbackup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-database-daily
   namespace: immich
 spec:
-  schedule: "CRON_TZ=Europe/Vienna 0 0 20 * * *"
+  schedule: "CRON_TZ=Europe/Vienna 0 6 23 * * *"
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -36,7 +36,7 @@ snapshotsEnabled: false
 
 schedules:
   daily:
-    schedule: "CRON_TZ=Europe/Vienna 00 20 * * *"
+    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
     template:
       ttl: "168h"
       defaultVolumesToFsBackup: true
@@ -48,7 +48,7 @@ schedules:
       excludedResources:
         - secrets
   weekly:
-    schedule: "CRON_TZ=Europe/Vienna 00 20 * * 0"
+    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
     template:
       ttl: "720h"
       defaultVolumesToFsBackup: true
@@ -60,7 +60,7 @@ schedules:
       excludedResources:
         - secrets
   monthly:
-    schedule: "CRON_TZ=Europe/Vienna 00 20 1 * *"
+    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
     template:
       ttl: "8760h"
       defaultVolumesToFsBackup: true


### PR DESCRIPTION
Temporary schedule bump so every backup (immich CNPG plugin + Velero daily/weekly/monthly) fires within 5 minutes. Will revert after one observed success per schedule.