### PR TITLE
fix: drop CRON_TZ prefix, standardise backup schedules on UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ Once the `argocd-webhook` ingress is live, add a webhook in the GitHub repo sett
 - **Events**: `Push`
 
 This triggers ArgoCD to sync immediately on every push instead of waiting for the 3-minute polling interval.
+
+## Backup schedules
+
+All backup schedules (Velero `Schedule`, CNPG `ScheduledBackup`) use **UTC**. CNPG's admission webhook rejects `CRON_TZ=` prefixes, so we standardise on UTC across both stacks. Convert from local when editing: Vienna is UTC+2 (CEST) or UTC+1 (CET).

--- a/apps/immich/postgres-scheduledbackup.yaml
+++ b/apps/immich/postgres-scheduledbackup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-database-daily
   namespace: immich
 spec:
-  schedule: "CRON_TZ=Europe/Vienna 0 6 23 * * *"
+  schedule: "0 10 21 * * *"
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:

--- a/apps/immich/postgres-scheduledbackup.yaml
+++ b/apps/immich/postgres-scheduledbackup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-database-daily
   namespace: immich
 spec:
-  schedule: "0 10 21 * * *"
+  schedule: "0 15 21 * * *"
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -36,7 +36,7 @@ snapshotsEnabled: false
 
 schedules:
   daily:
-    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
+    schedule: "15 21 * * *"
     template:
       ttl: "168h"
       defaultVolumesToFsBackup: true
@@ -48,7 +48,7 @@ schedules:
       excludedResources:
         - secrets
   weekly:
-    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
+    schedule: "15 21 * * *"
     template:
       ttl: "720h"
       defaultVolumesToFsBackup: true
@@ -60,7 +60,7 @@ schedules:
       excludedResources:
         - secrets
   monthly:
-    schedule: "CRON_TZ=Europe/Vienna 06 23 * * *"
+    schedule: "15 21 * * *"
     template:
       ttl: "8760h"
       defaultVolumesToFsBackup: true


### PR DESCRIPTION
## Why
CNPG's admission webhook rejects \`CRON_TZ=\` prefixes (counts fields strictly), so the immich \`ScheduledBackup\` never applied:
\`spec.schedule: Invalid value: \"CRON_TZ=Europe/Vienna 0 6 23 * * *\": Expected 5 to 6 fields, found 7\`

## Changes
- Drop \`CRON_TZ=Europe/Vienna\` prefix from all schedules (Velero + CNPG)
- Standardise on UTC everywhere
- README: short note on the convention

## Smoke-test time
21:15 UTC = 23:15 Europe/Vienna today.