### PR TITLE
chore: backup schedules at 20:00 UTC

### DIFF
--- a/apps/immich/postgres-scheduledbackup.yaml
+++ b/apps/immich/postgres-scheduledbackup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-database-daily
   namespace: immich
 spec:
-  schedule: "0 15 21 * * *"
+  schedule: "0 0 20 * * *"
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -36,7 +36,7 @@ snapshotsEnabled: false
 
 schedules:
   daily:
-    schedule: "15 21 * * *"
+    schedule: "0 20 * * *"
     template:
       ttl: "168h"
       defaultVolumesToFsBackup: true
@@ -48,7 +48,7 @@ schedules:
       excludedResources:
         - secrets
   weekly:
-    schedule: "15 21 * * *"
+    schedule: "0 20 * * 0"
     template:
       ttl: "720h"
       defaultVolumesToFsBackup: true
@@ -60,7 +60,7 @@ schedules:
       excludedResources:
         - secrets
   monthly:
-    schedule: "15 21 * * *"
+    schedule: "0 20 1 * *"
     template:
       ttl: "8760h"
       defaultVolumesToFsBackup: true


### PR DESCRIPTION
Daily 20:00 UTC across Velero (with weekly/monthly cadence restored) and immich CNPG.