### PR TITLE
fix(argocd): exclude ksops-image ImageVolume from Velero fs-backup

### DIFF
--- a/apps/argocd/values.yaml
+++ b/apps/argocd/values.yaml
@@ -5,6 +5,9 @@ configs:
     server.insecure: true
 
 repoServer:
+  podAnnotations:
+    backup.velero.io/backup-volumes-excludes: ksops-image
+
   env:
     - name: PATH
       value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/ksops/usr/local/bin


### PR DESCRIPTION
Velero PVB cannot resolve a host path for the `ksops-image` ImageVolume, causing daily backups to land as PartiallyFailed. Annotate repo-server pod so Velero skips it; the binary is reproducible from the pinned image.