### PR TITLE
chore: restore backup schedules to 22:00 UTC production cadence

### DIFF
--- a/apps/immich/postgres-scheduledbackup.yaml
+++ b/apps/immich/postgres-scheduledbackup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: immich-database-daily
   namespace: immich
 spec:
-  schedule: "0 21 22 * * *"
+  schedule: "0 0 22 * * *"
   backupOwnerReference: self
   method: plugin
   pluginConfiguration:

--- a/apps/velero/values.yaml
+++ b/apps/velero/values.yaml
@@ -36,7 +36,7 @@ snapshotsEnabled: false
 
 schedules:
   daily:
-    schedule: "21 22 * * *"
+    schedule: "0 22 * * *"
     template:
       ttl: "168h"
       defaultVolumesToFsBackup: true
@@ -48,7 +48,7 @@ schedules:
       excludedResources:
         - secrets
   weekly:
-    schedule: "21 22 * * *"
+    schedule: "0 22 * * 0"
     template:
       ttl: "720h"
       defaultVolumesToFsBackup: true
@@ -60,7 +60,7 @@ schedules:
       excludedResources:
         - secrets
   monthly:
-    schedule: "21 22 * * *"
+    schedule: "0 22 1 * *"
     template:
       ttl: "8760h"
       defaultVolumesToFsBackup: true


### PR DESCRIPTION
Smoke test done; revert all schedules to 22:00 UTC with proper daily/weekly/monthly cadence.