### PR TITLE
chore(immich): switch immich-database to recovery bootstrap (one-shot)

### DIFF
--- a/apps/immich/kustomization.yaml
+++ b/apps/immich/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - namespace.yaml
   - pvc.yaml
   - postgres-objectstore.yaml
-  - postgres-cluster.yaml
+  - postgres-cluster-recovery.yaml
   - postgres-scheduledbackup.yaml
   - ingress.yaml
 

--- a/apps/immich/postgres-cluster-recovery.yaml
+++ b/apps/immich/postgres-cluster-recovery.yaml
@@ -1,0 +1,38 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: immich-database
+  namespace: immich
+spec:
+  instances: 1
+
+  inheritedMetadata:
+    labels:
+      velero.io/exclude-from-backup: "true"
+
+  storage:
+    size: 10Gi
+    storageClass: local-path
+
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+
+  postgresql:
+    shared_preload_libraries: []
+
+  bootstrap:
+    recovery:
+      source: immich-database-source
+
+  externalClusters:
+    - name: immich-database-source
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: immich-database-store
+          serverName: immich-database
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: immich-database-store


### PR DESCRIPTION
Adds postgres-cluster-recovery.yaml and points kustomization at it so ArgoCD applies the recovery spec. Revert to postgres-cluster.yaml after restore succeeds.