### PR TITLE
fix(immich): override archive serverName during recovery

### DIFF
--- a/apps/immich/postgres-cluster-recovery.yaml
+++ b/apps/immich/postgres-cluster-recovery.yaml
@@ -36,3 +36,4 @@ spec:
       isWALArchiver: true
       parameters:
         barmanObjectName: immich-database-store
+        serverName: immich-database-v2


### PR DESCRIPTION
WAL archive path collides with pre-delete cluster. Override serverName to v2 so check_wal_archive passes.