### PR TITLE
feat(home-assistant): expose /dev/serial/by-id for ZBT-2 access

### DIFF
--- a/apps/home-assistant/deployment.yaml
+++ b/apps/home-assistant/deployment.yaml
@@ -99,6 +99,9 @@ spec:
         - name: localtime
           mountPath: /etc/localtime
           readOnly: true
+        - name: serial-by-id
+          mountPath: /dev/serial/by-id
+          readOnly: true
         resources:
           limits:
             cpu: "2"
@@ -139,3 +142,7 @@ spec:
       - name: ha-config
         configMap:
           name: home-assistant-config
+      - name: serial-by-id
+        hostPath:
+          path: /dev/serial/by-id
+          type: Directory


### PR DESCRIPTION
## Summary
- Mounts host `/dev/serial/by-id` into HA container (read-only)
- hostNetwork already on; container already privileged — no other changes
- Stable path: `/dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00`

## Test plan
- [ ] ArgoCD syncs after merge
- [ ] `kubectl -n home-assistant exec deploy/home-assistant -- ls -l /dev/serial/by-id` — ZBT-2 symlink visible
- [ ] Add ZHA in HA UI at that path, adapter `ember`, baudrate `460800`

🤖 Generated with [Claude Code](https://claude.com/claude-code)