### PR TITLE
fix(home-assistant): mount host /dev for full serial device access

### DIFF
--- a/apps/home-assistant/deployment.yaml
+++ b/apps/home-assistant/deployment.yaml
@@ -99,11 +99,8 @@ spec:
         - name: localtime
           mountPath: /etc/localtime
           readOnly: true
-        - name: serial-by-id
-          mountPath: /dev/serial/by-id
-          readOnly: true
-        - name: ttyacm0
-          mountPath: /dev/ttyACM0
+        - name: dev
+          mountPath: /dev
         resources:
           limits:
             cpu: "2"
@@ -144,11 +141,7 @@ spec:
       - name: ha-config
         configMap:
           name: home-assistant-config
-      - name: serial-by-id
+      - name: dev
         hostPath:
-          path: /dev/serial/by-id
+          path: /dev
           type: Directory
-      - name: ttyacm0
-        hostPath:
-          path: /dev/ttyACM0
-          type: CharDevice

--- a/apps/home-assistant/deployment.yaml
+++ b/apps/home-assistant/deployment.yaml
@@ -102,6 +102,8 @@ spec:
         - name: serial-by-id
           mountPath: /dev/serial/by-id
           readOnly: true
+        - name: ttyacm0
+          mountPath: /dev/ttyACM0
         resources:
           limits:
             cpu: "2"
@@ -146,3 +148,7 @@ spec:
         hostPath:
           path: /dev/serial/by-id
           type: Directory
+      - name: ttyacm0
+        hostPath:
+          path: /dev/ttyACM0
+          type: CharDevice


### PR DESCRIPTION
## Summary
- Replaces targeted `by-id` + `ttyACM0` mounts with single host `/dev` mount
- All serial devices (`ttyACM*`, `ttyUSB*`) and their `by-id` symlinks resolve correctly
- Fixes firmware flash failure: `FileNotFoundError: /dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00`

## Test plan
- [ ] ArgoCD syncs after merge
- [ ] `kubectl -n home-assistant exec deploy/home-assistant -- ls -l /dev/serial/by-id` — ZBT-2 symlink visible
- [ ] Firmware install succeeds in HA UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)