### PR TITLE
feat(otbr): add OpenThread Border Router app for ZBT-2 Thread support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ Once the `argocd-webhook` ingress is live, add a webhook in the GitHub repo sett
 
 This triggers ArgoCD to sync immediately on every push instead of waiting for the 3-minute polling interval.
 
+## Thread / OpenThread Border Router (OTBR)
+
+Thread support for Matter-over-Thread devices is provided by a standalone OTBR container (`apps/otbr/`). The Home Assistant Connect ZBT-2 is flashed with Thread RCP firmware and dedicated to Thread (no Zigbee on this radio).
+
+**Before deploying**, update two values in `apps/otbr/deployment.yaml` with the actual values from the K3s node:
+
+| Env var | How to find it |
+|---|---|
+| `OT_RCP_DEVICE` | `ls -l /dev/serial/by-id/` — use the `usb-Nabu_Casa_ZBT-2_*-if00` symlink |
+| `OT_INFRA_IF` | `ip -o link show` — host LAN interface (typically `end0` on Asahi) |
+
+**After ArgoCD syncs**, add the integration in Home Assistant:
+
+1. Settings → Devices & Services → Add Integration → **OpenThread Border Router** → URL `http://127.0.0.1:8081`
+2. Settings → Thread → set as preferred border router
+
+Verify the OTBR REST API is live: `curl http://<node-ip>:8081/node`
+
 ## Backup schedules
 
 All backup schedules (Velero `Schedule`, CNPG `ScheduledBackup`) use **UTC**. CNPG's admission webhook rejects `CRON_TZ=` prefixes, so we standardise on UTC across both stacks. Convert from local when editing: Vienna is UTC+2 (CEST) or UTC+1 (CET).

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otbr
+  namespace: otbr
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: otbr
+  template:
+    metadata:
+      labels:
+        app: otbr
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: otbr
+        # renovate: datasource=docker depName=openthread/border-router
+        image: openthread/border-router:latest@sha256:3ad738e6aaf8b9fac07f5377401cedc1b9932e02b2e5760ba38ac41ce7cad541
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        env:
+        - name: OT_RCP_DEVICE
+          # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
+          # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
+        - name: OT_INFRA_IF
+          # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
+          # Common value on Asahi Linux Mac Mini: end0
+          value: "end0"
+        - name: OT_THREAD_IF
+          value: "wpan0"
+        - name: OT_REST_LISTEN_ADDR
+          value: "0.0.0.0"
+        - name: OT_REST_LISTEN_PORT
+          value: "8081"
+        - name: OT_LOG_LEVEL
+          value: "5"
+        - name: TZ
+          value: "Europe/Vienna"
+        ports:
+        - containerPort: 8080
+          name: web-gui
+          protocol: TCP
+        - containerPort: 8081
+          name: rest-api
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: dev
+          mountPath: /dev
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: otbr-data-pvc
+      - name: dev
+        hostPath:
+          path: /dev
+          type: Directory

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: OT_RCP_DEVICE
           # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
           # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
-          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00?uart-baudrate=460800"
         - name: OT_INFRA_IF
           # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
           # Common value on Asahi Linux Mac Mini: end0

--- a/apps/otbr/kustomization.yaml
+++ b/apps/otbr/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: otbr
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- deployment.yaml

--- a/apps/otbr/namespace.yaml
+++ b/apps/otbr/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: otbr

--- a/apps/otbr/pvc.yaml
+++ b/apps/otbr/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: otbr-data-pvc
+  namespace: otbr
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
## Summary

- Adds `apps/otbr/` as a new ArgoCD-managed app running the official `openthread/border-router` image
- ZBT-2 (`usb-Nabu_Casa_ZBT-2_441BF684AD68-if00`) dedicated to Thread (already flashed with ot-rcp firmware)
- Uses `hostNetwork: true` + privileged + host `/dev` mount — same pattern as `apps/home-assistant/`
- REST API on port 8081; HA integrates via `http://127.0.0.1:8081`

## Post-merge steps

1. ArgoCD syncs `otbr` app automatically
2. Verify: `kubectl logs -n otbr deploy/otbr` → expect `Border router agent started`, `wpan0` up
3. Verify REST: `curl http://<node-ip>:8081/node` → returns JSON
4. HA → Add Integration → **OpenThread Border Router** → `http://127.0.0.1:8081`
5. HA → Thread → set as preferred border router

🤖 Generated with [Claude Code](https://claude.com/claude-code)