### PR TITLE
feat(matter-server): add python-matter-server app for Matter device support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,17 @@ ArgoCD's repo-server runs the ksops plugin to decrypt at sync time using the clu
 
 **Charts that force secrets into values files (e.g. PrepArr's `.Values.*.config.apiKey` rendered into ConfigMaps) are unavoidable leaks.** Before adopting such a chart, check whether all credentials can be wired through `existingSecret`-style references.
 
+## Image versioning
+
+**Always pin container images with both a semver tag and a sha256 digest** — `image:1.2.3@sha256:...`. Never use `latest` or undigested tags alone. This ensures reproducible deploys and protects against tag mutation.
+
+For images with no semver (e.g. `openthread/border-router` which only publishes `latest`), use `latest@sha256:...` and update the digest manually when upgrading.
+
+To get a digest:
+```bash
+nix shell nixpkgs#crane --command crane digest <image>:<tag>
+```
+
 ## Renovate
 
 `renovate.json5` auto-merges stable non-major updates via squash commits. To pin a version so Renovate tracks it, use an inline comment:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ Once the `argocd-webhook` ingress is live, add a webhook in the GitHub repo sett
 
 This triggers ArgoCD to sync immediately on every push instead of waiting for the 3-minute polling interval.
 
+## Matter Server
+
+Matter device support runs via `apps/matter-server/` (`ghcr.io/home-assistant-libs/python-matter-server`, official HA libs image). WebSocket on `:5580`.
+
+After ArgoCD syncs, add the integration in HA:
+
+- Settings → Devices & Services → Matter (discovered automatically) → URL `ws://127.0.0.1:5580/ws`
+
+Requires OTBR running for Matter-over-Thread devices (see below).
+
 ## Thread / OpenThread Border Router (OTBR)
 
 Thread support for Matter-over-Thread devices is provided by a standalone OTBR container (`apps/otbr/`). The Home Assistant Connect ZBT-2 is flashed with Thread RCP firmware and dedicated to Thread (no Zigbee on this radio).

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: matter-server
-        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server versioning=loose
-        image: ghcr.io/home-assistant-libs/python-matter-server:stable
+        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: matter-server
-        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server versioning=loose
+        image: ghcr.io/home-assistant-libs/python-matter-server:stable
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: matter-server
+  namespace: matter-server
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: matter-server
+  template:
+    metadata:
+      labels:
+        app: matter-server
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+      - name: matter-server
+        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        args:
+        - --storage-path
+        - /data
+        - --paa-trust-store-path
+        - /data/credentials
+        env:
+        - name: TZ
+          value: "Europe/Vienna"
+        ports:
+        - containerPort: 5580
+          name: ws
+          protocol: TCP
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: matter-server-data-pvc

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/kustomization.yaml
+++ b/apps/matter-server/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: matter-server
+
+resources:
+- namespace.yaml
+- pvc.yaml
+- deployment.yaml

--- a/apps/matter-server/namespace.yaml
+++ b/apps/matter-server/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matter-server

--- a/apps/matter-server/pvc.yaml
+++ b/apps/matter-server/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: matter-server-data-pvc
+  namespace: matter-server
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 1Gi

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: OT_RCP_DEVICE
           # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
           # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
-          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00?uart-baudrate=460800"
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
         - name: OT_INFRA_IF
           # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
           # Common value on Asahi Linux Mac Mini: end0

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: OT_RCP_DEVICE
           # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
           # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
-          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00?uart-baudrate=460800"
         - name: OT_INFRA_IF
           # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
           # Common value on Asahi Linux Mac Mini: end0


### PR DESCRIPTION
## Summary

- Adds `apps/matter-server/` running the official `ghcr.io/home-assistant-libs/python-matter-server:8.1.2`
- WebSocket on `:5580` → HA connects via `ws://127.0.0.1:5580/ws`
- `hostNetwork: true` + privileged — required for IPv6 multicast / Matter commissioning
- Works alongside the existing OTBR app for Matter-over-Thread devices

## Post-merge

1. ArgoCD syncs `matter-server` app
2. HA → Settings → Devices & Services → Matter (auto-discovered) → submit `ws://127.0.0.1:5580/ws`
3. Commission Matter device via HA Companion app

🤖 Generated with [Claude Code](https://claude.com/claude-code)