### PR TITLE
chore(renovate): weekly Monday-night schedule, group all deps into one PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -11,8 +11,10 @@
       "/\\.yaml$/"
     ]
   },
+  "schedule": ["after 8pm on monday", "before 6am on tuesday"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
+  "groupName": "all dependencies",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Runs only Monday 20:00–Tuesday 06:00
- Groups all dependency updates into a single PR per cycle
- Retains existing squash-automerge for stable non-major updates

## Test plan
- [ ] Verify Renovate next run opens one grouped PR
- [ ] Confirm PR is scheduled for Monday night window