### PR TITLE
fix(matter-server): correct paa-root-cert-dir arg name

### DIFF
--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: matter-server
-        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server versioning=loose
-        image: ghcr.io/home-assistant-libs/python-matter-server:stable
+        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.2
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - --storage-path
         - /data
-        - --paa-trust-store-path
+        - --paa-root-cert-dir
         - /data/credentials
         env:
         - name: TZ

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
       - name: matter-server
-        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
+        # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server versioning=loose
+        image: ghcr.io/home-assistant-libs/python-matter-server:stable
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/matter-server/deployment.yaml
+++ b/apps/matter-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: matter-server
         # renovate: datasource=docker depName=ghcr.io/home-assistant-libs/python-matter-server
-        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0@sha256:170aa093ce91c76cde4cc390918307590f0f5558fcec93f913af3cb019e6562a
+        image: ghcr.io/home-assistant-libs/python-matter-server:8.1.0
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: OT_RCP_DEVICE
           # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
           # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
-          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00?uart-baudrate=460800"
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
         - name: OT_INFRA_IF
           # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
           # Common value on Asahi Linux Mac Mini: end0

--- a/apps/otbr/deployment.yaml
+++ b/apps/otbr/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: OT_RCP_DEVICE
           # Replace with the actual by-id symlink from: ls -l /dev/serial/by-id/
           # Expected format: usb-Nabu_Casa_ZBT-2_<SERIAL>-if00
-          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_REPLACE_ME-if00?uart-baudrate=460800"
+          value: "spinel+hdlc+uart:///dev/serial/by-id/usb-Nabu_Casa_ZBT-2_441BF684AD68-if00?uart-baudrate=460800"
         - name: OT_INFRA_IF
           # Replace with the host LAN interface: ip -o link show | grep -v 'lo\|cni\|flannel\|veth\|docker'
           # Common value on Asahi Linux Mac Mini: end0


### PR DESCRIPTION
`--paa-trust-store-path` is not a valid argument; pod was crashing on startup.
Correct flag per `matter-server --help` is `--paa-root-cert-dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)